### PR TITLE
Cross-compilation to armel/armhf, linking fix for i386

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -28,6 +28,8 @@ This use case is covered by chezschemeX.Y-dev.
 
 Traditionally upstream has distributed four different builds from
 these combinations: with/without compiler, with/without threading. The
-Debian package comes with the compiler and with threading.
+Debian package comes with the compiler and with threading. The
+exception is armel/armhf where upstream does not have a threaded
+machine type for ARM.
 
- -- Göran Weinholt <goran@weinholt.se>, Sun, 10 Dec 2017 23:06:48 +0100
+ -- Göran Weinholt <goran@weinholt.se>, Sun, 17 Dec 2017 19:33:40 +0100

--- a/debian/README.source
+++ b/debian/README.source
@@ -26,4 +26,14 @@ patching source code in c/ or s/. The tests take many hours to run and
 are overkill for regular builds. They are enabled with
 DEB_BUILD_OPTIONS="fullcheck".
 
- -- Göran Weinholt <goran@weinholt.se>, Tue, 12 Dec 2017 22:06:20 +0100
+Chez Scheme can be crosscompiled to 32-bit ARM (armhf can be
+substituted with armel):
+
+  dpkg --add-architecture armhf
+  apt update
+  apt-get install crossbuild-essential-armhf
+  apt-get build-dep -aarmhf chezscheme
+  # Or: apt-get install zlib1g-dev:armhf libx11-dev:armhf libncurses5-dev:armhf
+  CONFIG_SITE=/etc/dpkg-cross/cross-config.armhf dpkg-buildpackage -aarmhf -B
+
+ -- Göran Weinholt <goran@weinholt.se>, Sun, 17 Dec 2017 19:30:18 +0100

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+chezscheme (9.5+dfsg-2) unstable; urgency=low
+
+  * Add support for cross-building from i386/amd64 to armel/armhf.
+  * Fix zlib linking in i386 builds.
+
+ -- Göran Weinholt <goran@weinholt.se>  Sun, 17 Dec 2017 17:38:13 +0100
+
 chezscheme (9.5+dfsg-1) unstable; urgency=low
 
   * Initial release (closes: #823425).

--- a/debian/chezscheme9.5-dev.install
+++ b/debian/chezscheme9.5-dev.install
@@ -1,3 +1,3 @@
 #!/usr/bin/dh-exec
-build/boot/${MACHINE_TYPE}/kernel.o => usr/lib/${DEB_HOST_MULTIARCH}/csv${CHEZ_VERSION}/${MACHINE_TYPE}/
-usr/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/scheme.h => usr/include/${DEB_HOST_MULTIARCH}/csv${CHEZ_VERSION}/${MACHINE_TYPE}/
+build/boot/${HOST_MACHINE_TYPE}/kernel.o => usr/lib/${DEB_HOST_MULTIARCH}/csv${CHEZ_VERSION}/${HOST_MACHINE_TYPE}/
+usr/lib/csv${CHEZ_VERSION}/${HOST_MACHINE_TYPE}/scheme.h => usr/include/${DEB_HOST_MULTIARCH}/csv${CHEZ_VERSION}/${HOST_MACHINE_TYPE}/

--- a/debian/chezscheme9.5.install
+++ b/debian/chezscheme9.5.install
@@ -2,5 +2,5 @@
 usr/bin/scheme => usr/bin/chezscheme${CHEZ_VERSION}
 usr/bin/petite => usr/bin/petite${CHEZ_VERSION}
 usr/bin/scheme-script => usr/bin/scheme-script${CHEZ_VERSION}
-usr/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/petite.boot => usr/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/petite.boot
-usr/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/scheme.boot => usr/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/scheme.boot
+usr/lib/csv${CHEZ_VERSION}/${HOST_MACHINE_TYPE}/petite.boot => usr/lib/csv${CHEZ_VERSION}/${HOST_MACHINE_TYPE}/petite.boot
+usr/lib/csv${CHEZ_VERSION}/${HOST_MACHINE_TYPE}/scheme.boot => usr/lib/csv${CHEZ_VERSION}/${HOST_MACHINE_TYPE}/scheme.boot

--- a/debian/clean
+++ b/debian/clean
@@ -1,1 +1,2 @@
 build/
+crossbuilder/

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Vcs-Git: https://anonscm.debian.org/git/collab-maint/chezscheme.git
 Vcs-Browser: https://anonscm.debian.org/gitweb/?p=collab-maint/chezscheme.git
 
 Package: chezscheme9.5
-Architecture: i386 amd64
+Architecture: i386 amd64 armel armhf
 Multi-Arch: foreign
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Built-Using: ${misc:Built-Using}
@@ -26,7 +26,7 @@ Description: Reliable, high performance Scheme compiler (version 9.5)
 
 Package: chezscheme9.5-dev
 Section: devel
-Architecture: i386 amd64
+Architecture: i386 amd64 armel armhf
 Multi-Arch: same
 Depends: chezscheme9.5 (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Description: Reliable, high performance Scheme compiler (C development files)

--- a/debian/patches/0001-Dynamically-link-with-the-system-s-installed-zlib.patch
+++ b/debian/patches/0001-Dynamically-link-with-the-system-s-installed-zlib.patch
@@ -2,12 +2,44 @@ From: =?utf-8?q?G=C3=B6ran_Weinholt?= <goran@weinholt.se>
 Date: Sun, 10 Dec 2017 19:16:01 +0100
 Subject: Dynamically link with the system's installed zlib
 
+This changes the C makefiles to use $(LD), to stop building zlib, and
+to not statically link -lz into the kernel.
 ---
- c/Mf-base  | 6 ------
- c/Mf-ta6le | 8 ++++----
- c/Mf-ti3le | 6 +++---
- 3 files changed, 7 insertions(+), 13 deletions(-)
+ c/Mf-arm32le | 8 ++++----
+ c/Mf-base    | 6 ------
+ c/Mf-ta6le   | 8 ++++----
+ c/Mf-ti3le   | 8 ++++----
+ 4 files changed, 12 insertions(+), 18 deletions(-)
 
+diff --git a/c/Mf-arm32le b/c/Mf-arm32le
+index c4564a5..d6f8abb 100644
+--- a/c/Mf-arm32le
++++ b/c/Mf-arm32le
+@@ -16,7 +16,7 @@
+ m = arm32le
+ Cpu = ARMV6
+ 
+-mdclib = -lm -ldl -lncurses -lrt
++mdclib = -lm -ldl -lncurses -lrt -lz
+ C = ${CC} ${CPPFLAGS} -Wpointer-arith -Wextra -Werror -Wno-implicit-fallthrough -O2 ${CFLAGS}
+ o = o
+ mdsrc = arm32le.c
+@@ -26,12 +26,12 @@ mdobj = arm32le.o
+ .SUFFIXES: .c .o
+ 
+ .c.o:
+-	$C -c -D${Cpu} -I${Include} -I../zlib $*.c
++	$C -c -D${Cpu} -I${Include} $*.c
+ 
+ include Mf-base
+ 
+-${Kernel}: ${kernelobj} ../zlib/libz.a
+-	ld -r -X -o ${Kernel} ${kernelobj} ../zlib/libz.a
++${Kernel}: ${kernelobj}
++	$(LD) -r -X -o ${Kernel} ${kernelobj}
+ 
+ ${Scheme}: ${Kernel} ${Main}
+ 	$C -rdynamic -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
 diff --git a/c/Mf-base b/c/Mf-base
 index cc23047..4c101a1 100644
 --- a/c/Mf-base
@@ -28,7 +60,7 @@ index cc23047..4c101a1 100644
  	rm -f *.$o ${mdclean}
  	rm -f Make.out
 diff --git a/c/Mf-ta6le b/c/Mf-ta6le
-index 206afc5..1fff8d9 100644
+index 206afc5..1141c12 100644
 --- a/c/Mf-ta6le
 +++ b/c/Mf-ta6le
 @@ -16,7 +16,7 @@
@@ -52,14 +84,23 @@ index 206afc5..1fff8d9 100644
 -${Kernel}: ${kernelobj} ../zlib/libz.a
 -	ld -melf_x86_64 -r -X -o ${Kernel} ${kernelobj} ../zlib/libz.a
 +${Kernel}: ${kernelobj}
-+	ld -melf_x86_64 -r -X -o ${Kernel} ${kernelobj}
++	$(LD) -melf_x86_64 -r -X -o ${Kernel} ${kernelobj}
  
  ${Scheme}: ${Kernel} ${Main}
  	$C -rdynamic -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
 diff --git a/c/Mf-ti3le b/c/Mf-ti3le
-index 3883602..48b4fad 100644
+index 3883602..c7308c5 100644
 --- a/c/Mf-ti3le
 +++ b/c/Mf-ti3le
+@@ -16,7 +16,7 @@
+ m = ti3le
+ Cpu = I386
+ 
+-mdclib = -lm -ldl -lncurses -lpthread -lrt
++mdclib = -lm -ldl -lncurses -lpthread -lrt -lz
+ C = ${CC} ${CPPFLAGS} -m32 -msse2 -Wpointer-arith -Wall -Wextra -Werror -Wno-implicit-fallthrough -O2 -D_REENTRANT -pthread ${CFLAGS}
+ o = o
+ mdsrc = i3le.c
 @@ -26,12 +26,12 @@ mdobj = i3le.o
  .SUFFIXES: .c .o
  
@@ -72,7 +113,7 @@ index 3883602..48b4fad 100644
 -${Kernel}: ${kernelobj} ../zlib/libz.a
 -	ld -melf_i386 -r -X -o ${Kernel} ${kernelobj} ../zlib/libz.a
 +${Kernel}: ${kernelobj}
-+	ld -melf_i386 -r -X -o ${Kernel} ${kernelobj} -L/usr/lib/${DEB_HOST_MULTIARCH}/ -lz
++	$(LD) -melf_i386 -r -X -o ${Kernel} ${kernelobj}
  
  ${Scheme}: ${Kernel} ${Main}
  	$C -rdynamic -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}

--- a/debian/rules
+++ b/debian/rules
@@ -8,19 +8,25 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 DOPACKAGES = $(shell dh_listpackages)
 
-# Translate the host architecture to terms ./configure understands.
+# Translate the host architecture (the arch we're building for) to
+# terms the build system understands.
 ifeq ($(DEB_HOST_GNU_TYPE), x86_64-linux-gnu)
-    export MACHINE_TYPE = ta6le
+    export HOST_MACHINE_TYPE = ta6le
 else ifeq ($(DEB_HOST_GNU_TYPE), i386-linux-gnu)
-    export MACHINE_TYPE = ti3le
+    export HOST_MACHINE_TYPE = ti3le
+else ifeq ($(DEB_HOST_GNU_TYPE), arm-linux-gnueabihf)
+    export HOST_MACHINE_TYPE = arm32le
+else ifeq ($(DEB_HOST_GNU_TYPE), arm-linux-gnueabi)
+    export HOST_MACHINE_TYPE = arm32le
 else
     $(error Can not yet build for $(DEB_HOST_GNU_TYPE))
 endif
 ifeq ($(origin CC),default)
 CC := $(DEB_HOST_GNU_TYPE)-gcc
+LD := $(DEB_HOST_GNU_TYPE)-ld
 endif
 
-LIBDIR=usr/lib/csv$(CHEZ_VERSION)/$(MACHINE_TYPE)
+LIBDIR=usr/lib/csv$(CHEZ_VERSION)/$(HOST_MACHINE_TYPE)
 
 # Chez Scheme statically links with r6rs-nanopass-dev.
 NANOPASS_SRC = $(shell dpkg-query -W -f='$${source:Package} (= $${source:Version})\n' r6rs-nanopass-dev)
@@ -30,7 +36,14 @@ SUBSTVARS = -Vmisc:Built-Using="$(NANOPASS_SRC)"
 	dh $@
 
 override_dh_auto_configure:
-	CC=$(CC) ./configure --workarea=build -m=$(MACHINE_TYPE) --threads --installprefix=/usr --temproot=$(shell pwd)/debian/tmp
+ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
+	CC=$(CC) ./configure --workarea=build -m=$(HOST_MACHINE_TYPE) --threads --installprefix=/usr --temproot=$(shell pwd)/debian/tmp
+else
+	./configure --workarea=crossbuilder --threads --installprefix=/usr --temproot=$(shell pwd)/debian/tmp
+	make -C crossbuilder
+	./workarea $(HOST_MACHINE_TYPE)
+	mv $(HOST_MACHINE_TYPE) build
+endif
 	cp -a release_notes/ build/
 	cp -a csug/ build/
 	(echo "\def\INSERTREVISIONMONTHSPACEYEAR{}"; cat csug/copyright.stex) > \
@@ -42,14 +55,24 @@ ifeq (fullcheck,$(filter fullcheck,$(DEB_BUILD_OPTIONS)))
 endif
 
 override_dh_auto_build:
+ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
 	make -C build
+else
+	$(eval BUILD_MACHINE_TYPE = $(shell awk -F= '/^m=/ {print $$2}' crossbuilder/Mf-install))
+	make -C build/s -f Mf-cross m=$(BUILD_MACHINE_TYPE) xm=$(HOST_MACHINE_TYPE) base=$(CURDIR)/crossbuilder
+	make -C build/c CC=$(CC) LD=$(LD)
+endif
 ifneq (,$(filter chezscheme$(CHEZ_VERSION)-doc,$(DOPACKAGES)))
 	make -C build/release_notes Scheme=scheme STEXLIB=/usr/share/stex
 	make -C build/csug Scheme=scheme STEXLIB=/usr/share/stex
 endif
 
 override_dh_auto_install:
+ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
 	make install
+else
+	make -C build -f ../crossbuilder/Mf-install m=$(HOST_MACHINE_TYPE)
+endif
 	sed -e 's,^\\fI\(Chez Scheme\)\\fP,chezscheme$(CHEZ_VERSION) \- Chez Scheme,' \
 	    -e 's,^\\fI\(Petite Chez Scheme\)\\fP,petite$(CHEZ_VERSION) \- Petite Chez Scheme,' \
 	    build/scheme.1 > build/chezscheme$(CHEZ_VERSION).1


### PR DESCRIPTION
Hello Barak,

I've worked on cross compilation and the changes are now ready for your review.

I guess the buildd's don't support cross compilation, so this adds a small burden on the uploader. Instructions are included.

No news from da-manager@ nor collab-maint.

/Göran